### PR TITLE
ML service is returning confidence info and not anymore probability

### DIFF
--- a/Hands-on lab/lab-files/BigDataTravel/BigDataTravel/Default.aspx.cs
+++ b/Hands-on lab/lab-files/BigDataTravel/BigDataTravel/Default.aspx.cs
@@ -233,19 +233,20 @@ namespace BigDataTravel
 
                     if (response.IsSuccessStatusCode)
                     {
-                        var result = await response.Content.ReadAsStringAsync();
-                        var token = JToken.Parse(result);
+                        var responseResult = await response.Content.ReadAsStringAsync();
+                        var token = JToken.Parse(responseResult);
                         var parsedResult = JsonConvert.DeserializeObject<List<PredictionResult>>((string)token);
-
-                        if (parsedResult[0].prediction == 1)
+                        var result = parsedResult[0];
+                        double confidence = double.Parse(result.confidence.Replace("[", string.Empty).Replace("]", string.Empty).Split(new Char[] {','})[0]);
+                        if (result.prediction == 1)
                         {
                             this.prediction.ExpectDelays = true;
-                            this.prediction.Confidence = parsedResult[0].probability;
+                            this.prediction.Confidence = confidence;
                         }
-                        else if (parsedResult[0].prediction == 0)
+                        else if (result.prediction == 0)
                         {
                             this.prediction.ExpectDelays = false;
-                            this.prediction.Confidence = parsedResult[0].probability;
+                            this.prediction.Confidence = confidence;
                         }
                         else
                         {
@@ -295,7 +296,7 @@ namespace BigDataTravel
     public class PredictionResult
     {
         public double prediction { get; set; }
-        public double probability { get; set; }
+        public string confidence { get; set; }
     }
 
     public class ForecastResult


### PR DESCRIPTION
Fix Issue #43 

`probability` is not anymore returned by the AML Model, it's not `confidence`, here is a sample returned by this AML Model now:
```
[{"prediction": "1.0", "confidence": "[0.439352609565,0.560647390435]"}, {"prediction": "0.0", "confidence": "[0.698379692962,0.301620307038]"}]
```